### PR TITLE
Fix repository key in typst.toml

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -5,8 +5,7 @@ entrypoint = "index.typ"
 authors = ["Thumus"]
 license = "MIT"
 description = "A brainfuck implementation in pure Typst"
-repository = "git@github.com:Thumuss/brainfuck.git"
-homepage = "https://github.com/Thumuss/brainfuck"
+repository = "https://github.com/Thumuss/brainfuck"
 keywords = [
     "brainfuck",
     "esoteric",


### PR DESCRIPTION
The repository key expects a browser-navigable URL. If it and the homepage key are identical, the homepage key should be omitted. As-is, the GitHub link on the Universe page is broken.

It would also be great if you could fix the broken images on the Universe page.